### PR TITLE
Also test documentation build via CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,3 +24,16 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run tests
         run: cargo test
+
+  doc:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build documentation
+        run: |
+          rustdoc_output=$(cargo doc -q 2>&1)
+          if [ ! -z "${rustdoc_output}" ]; then
+            echo -e "${rustdoc_output}"
+            exit 1
+          fi


### PR DESCRIPTION
This catches errors in the documentation linking (using intra-doc-links)
early.

Closes #4.