### PR TITLE
Configure git user for release workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,8 @@ jobs:
       - name: Create release commit
         run: |
           sed -i "s/^version = .*$/version = \"${VERSION}\"/" Cargo.toml
+          git config --global user.email 'noreply@github.com'
+          git config --global user.name 'GitHub Actions Release Bot'
           git add Cargo.toml
           git commit -m "Release version \`${VERSION}\`"
           git push


### PR DESCRIPTION
If this is not done, the build will fail with an error like [this].

    Author identity unknown

    *** Please tell me who you are.

    Run

      git config --global user.email "you@example.com"
      git config --global user.name "Your Name"

    to set your account's default identity.
    Omit --global to set the identity only in this repository.

    fatal: empty ident name (for <runner@fv-az129-416.unsdhqlsd1aehetrpucgquyceg.gx.internal.cloudapp.net>) not allowed

[this]: https://github.com/jfrimmel/partial-array/runs/3571236827?check_suite_focus=true