### PR TITLE
Fixup release process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,6 +34,6 @@ jobs:
       - name: Create tag
         run: git tag -a "${VERSION}" -m "v${VERSION}"
       - name: Push changes
-        run: git push --tags HEAD
+        run: git push --tags origin HEAD
       - name: Publish to crates.io
         run: cargo publish --token "${CRATES_IO}"


### PR DESCRIPTION
Again, testing the release process is hard, therefore one more issue
crept in: the `git push` command was ill-formed (missed the remote).