### PR TITLE
Fix consecutive calls to Extend::extend

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,13 +359,10 @@ impl<T, const N: usize> Extend<T> for PartialArray<T, N> {
         let remaining = (self.filled..N).len();
         let mut iter = iter.into_iter();
 
-        iter.by_ref()
-            .take(remaining)
-            .enumerate()
-            .for_each(|(i, element)| {
-                self.array[i] = MaybeUninit::new(element);
-                self.filled += 1;
-            });
+        iter.by_ref().take(remaining).for_each(|element| {
+            self.array[self.filled] = MaybeUninit::new(element);
+            self.filled += 1;
+        });
 
         // check, that there are no more elements left
         let remaining = iter.count();

--- a/src/tests/extend.rs
+++ b/src/tests/extend.rs
@@ -3,7 +3,7 @@ use crate::PartialArray;
 #[test]
 fn empty() {
     let mut partial_array: PartialArray<u8, 3> = Default::default();
-    partial_array.extend([1,2].iter().copied());
+    partial_array.extend([1, 2].iter().copied());
     assert_eq!(partial_array.len(), 2);
     assert_eq!(partial_array[0], 1);
     assert_eq!(partial_array[1], 2);
@@ -12,7 +12,7 @@ fn empty() {
 #[test]
 fn nonempty() {
     let mut partial_array: PartialArray<u8, 3> = Default::default();
-    partial_array.extend([1,2].iter().copied());
+    partial_array.extend([1, 2].iter().copied());
     partial_array.extend(Some(3));
     assert_eq!(partial_array.len(), 3);
     assert_eq!(partial_array[0], 1);

--- a/src/tests/extend.rs
+++ b/src/tests/extend.rs
@@ -1,0 +1,27 @@
+use crate::PartialArray;
+
+#[test]
+fn empty() {
+    let mut partial_array: PartialArray<u8, 3> = Default::default();
+    partial_array.extend([1,2].iter().copied());
+    assert_eq!(partial_array.len(), 2);
+    assert_eq!(partial_array[0], 1);
+    assert_eq!(partial_array[1], 2);
+}
+
+#[test]
+fn nonempty() {
+    let mut partial_array: PartialArray<u8, 3> = Default::default();
+    partial_array.extend([1,2].iter().copied());
+    partial_array.extend(Some(3));
+    assert_eq!(partial_array.len(), 3);
+    assert_eq!(partial_array[0], 1);
+    assert_eq!(partial_array[2], 3);
+}
+
+#[test]
+#[should_panic(expected = "Iterator has 1 elements to much")]
+fn full() {
+    let mut partial_array: PartialArray<u8, 3> = [1, 2, 3].iter().copied().collect();
+    partial_array.extend(Some(4));
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,6 +1,7 @@
 mod debug;
 mod deref;
 mod eq;
+mod extend;
 mod from_iter;
 mod into_iter;
 mod size_layout;


### PR DESCRIPTION
Hey!

Just found your library the other day and it's exactly what I need to get rid of some unsafe code in a project. When I integrated it my tests stopped working and I traced it back to a small bug that has rather significant impact. It was a quick fix, though! What follows is the explanation from the commit message:

Previously, every call to Extend would store all new elements at the start of the array, potentially overwriting elements that were added previously. At the same time, the field "filled" was increased, breaking the core safety invariant, since later entries which are still uninitialized would now be assumed to be initialized and returned.